### PR TITLE
test: Add passing test for program deployment

### DIFF
--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -1,5 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
+import { expect } from "chai";
 import { SolanaProgram } from "../target/types/solana_program";
 
 describe("solana-program", () => {
@@ -8,9 +9,14 @@ describe("solana-program", () => {
 
   const program = anchor.workspace.solanaProgram as Program<SolanaProgram>;
 
-  it("Is initialized!", async () => {
-    // Add your test here.
+  it("Program deploys successfully and can be initialized", async () => {
+    // Call the initialize method
     const tx = await program.methods.initialize().rpc();
-    console.log("Your transaction signature", tx);
+    
+    // Assert that a valid transaction signature was returned
+    expect(tx).to.be.a("string");
+    expect(tx.length).to.be.greaterThan(0);
+    
+    console.log("Initialization successful! Transaction signature:", tx);
   });
 });


### PR DESCRIPTION
Resolves #10. Adds a simple Chai test to verify that the program deploys successfully and the `initialize` method can be called.