### PR TITLE
Rebase and merge create stream feature 

### DIFF
--- a/programs/solana-program/src/lib.rs
+++ b/programs/solana-program/src/lib.rs
@@ -11,6 +11,7 @@ declare_id!("8M5yieUh7pxwUi1YBByDF82nqoorZwaKi8dBoMVpurFa");
 
 const MIN_STREAM_DURATION: i64 = 60;
 const STREAM_STATUS_ACTIVE: u8 = 1;
+const VESTING_TYPE_LINEAR: u8 = 0;
 #[program]
 pub mod solana_program {
     use super::*;
@@ -120,7 +121,7 @@ pub mod solana_program {
         stream.nonce = nonce;
         stream.bump = ctx.bumps.stream;
 
-        stream.vesting_type = 0;
+        stream.vesting_type = VESTING_TYPE_LINEAR;
         stream.status = STREAM_STATUS_ACTIVE;
         stream.cancelable = true;
         stream.milestone_count = 0;
@@ -277,8 +278,64 @@ pub struct CreateStream<'info> {
 #[derive(Accounts)]
 pub struct Withdraw {}
 
+
 #[derive(Accounts)]
-pub struct Cancel {}
+pub struct Cancel<'info> {
+    #[account(mut)]
+    pub creator: Signer<'info>,
+
+    pub mint: InterfaceAccount<'info, Mint>,
+
+    #[account(
+        mut,
+        seeds = [
+            b"stream",
+            stream.creator.as_ref(),
+            stream.recipient.as_ref(),
+            &stream.nonce.to_le_bytes()
+        ],
+        bump = stream.bump,
+        has_one = creator,
+        has_one = mint,
+        constraint = stream.status == STREAM_STATUS_ACTIVE
+            @ ErrorCode::StreamNotActive,
+        constraint = stream.cancelable
+            @ ErrorCode::StreamNotCancelable,
+    )]
+    pub stream: Account<'info, StreamAccount>,
+
+    #[account(
+        mut,
+        associated_token::mint = mint,
+        associated_token::authority = stream,
+        associated_token::token_program = token_program,
+    )]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        constraint = creator_token_account.owner == creator.key()
+            @ ErrorCode::InvalidTokenOwner,
+        constraint = creator_token_account.mint == mint.key()
+            @ ErrorCode::InvalidMint,
+    )]
+    pub creator_token_account:
+        InterfaceAccount<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        constraint = recipient_token_account.owner
+            == stream.recipient
+            @ ErrorCode::InvalidRecipient,
+        constraint = recipient_token_account.mint
+            == mint.key()
+            @ ErrorCode::InvalidMint,
+    )]
+    pub recipient_token_account:
+        InterfaceAccount<'info, TokenAccount>,
+
+    pub token_program: Interface<'info, TokenInterface>,
+}
 
 #[derive(Accounts)]
 pub struct InitializeConfig<'info> {

--- a/programs/solana-program/src/lib.rs
+++ b/programs/solana-program/src/lib.rs
@@ -203,11 +203,9 @@ pub mod solana_program {
 
     // fees
     config.withdraw_fee_bps = 100; // 1%
-    config.cancel_fee_lamports = 5_000;
 
     // fee limits
     config.max_withdraw_fee_bps = 500; // 5%
-    config.max_cancel_fee_lamports = 1_000_000;
 
     // timelock
     config.fee_change_timelock_seconds = 86400; // 24h
@@ -364,7 +362,6 @@ pub struct InitializeConfig<'info> {
 )]
 pub struct PendingFees {
     pub new_withdraw_fee_bps: u16,
-    pub new_cancel_fee_lamports: u64,
     pub effective_at: i64,
 }
 

--- a/programs/solana-program/src/lib.rs
+++ b/programs/solana-program/src/lib.rs
@@ -375,11 +375,9 @@ pub struct ConfigAccount {
 
 
     pub withdraw_fee_bps: u16,
-    pub cancel_fee_lamports: u64,
 
 
     pub max_withdraw_fee_bps: u16,
-    pub max_cancel_fee_lamports: u64,
 
     pub fee_change_timelock_seconds: u64,
 

--- a/programs/solana-program/src/lib.rs
+++ b/programs/solana-program/src/lib.rs
@@ -486,6 +486,12 @@ pub enum ErrorCode {
 
     #[msg("Transfer fee tokens unsupported")]
     TransferFeeMintUnsupported,
+
+    #[msg("Stream not active")]
+    StreamNotActive,
+
+    #[msg("Stream not cancelable")]
+    StreamNotCancelable,
 }
 
 #[event]

--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -467,7 +467,10 @@ describe("solana-program", () => {
       )
     ).amount;
 
-    const hugeAmount = new anchor.BN(creatorBalance.toString()).add(new anchor.BN(1))
+    const hugeAmount =
+      new anchor.BN(creatorBalance.toString())
+        .add(new anchor.BN(1));
+
     try {
       await program.methods
         .createStream(
@@ -577,7 +580,7 @@ describe("solana-program", () => {
     const nonce = new anchor.BN(999999);
 
     const startTs = new anchor.BN(
-      Math.floor(Date.now() / 1000) + 10
+      Math.floor(Date.now() / 1000) + 60
     );
 
     const endTs = startTs.add(new anchor.BN(100));

--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -15,7 +15,6 @@ import {
   createInitializeTransferFeeConfigInstruction,
   createInitializeMintInstruction,
   getMintLen,
-  createAssociatedTokenAccountIdempotent,
   mintToChecked,
 } from "@solana/spl-token";
 import { expect } from "chai";

--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -238,6 +238,14 @@ describe("solana-program", () => {
     expect(
       vaultAccount.amount.toString()
     ).to.equal(amount.toString());
+
+    expect(
+      vaultAccount.owner.toBase58()
+    ).to.equal(streamPDA.toBase58());
+
+    expect(
+      vaultAccount.mint.toBase58()
+    ).to.equal(mint.toBase58());
   });
 
   // =========================================================

--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -435,10 +435,7 @@ describe("solana-program", () => {
       )
     ).amount;
 
-    const hugeAmount = new anchor.BN(
-      Number(creatorBalance) + 1
-    );
-
+    const hugeAmount = new anchor.BN(creatorBalance.toString()).add(new anchor.BN(1))
     try {
       await program.methods
         .createStream(

--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -155,7 +155,7 @@ describe("solana-program", () => {
 
     const now = Math.floor(Date.now() / 1000);
 
-    const startTs = new anchor.BN(now + 5);
+    const startTs = new anchor.BN(now + 60);
 
     const endTs = startTs.add(new anchor.BN(100));
 
@@ -225,7 +225,7 @@ describe("solana-program", () => {
 
     const now = Math.floor(Date.now() / 1000);
 
-    const startTs = new anchor.BN(now + 5);
+    const startTs = new anchor.BN(now + 60);
 
     const endTs = startTs.add(new anchor.BN(100));
 
@@ -384,7 +384,7 @@ describe("solana-program", () => {
 
     const now = Math.floor(Date.now() / 1000);
 
-    const startTs = new anchor.BN(now + 5);
+    const startTs = new anchor.BN(now + 60);
 
     const endTs = startTs.add(new anchor.BN(100));
 
@@ -424,7 +424,7 @@ describe("solana-program", () => {
 
     const now = Math.floor(Date.now() / 1000);
 
-    const startTs = new anchor.BN(now + 5);
+    const startTs = new anchor.BN(now + 60);
 
     const endTs = startTs.add(new anchor.BN(100));
 

--- a/tests/solana-program.ts
+++ b/tests/solana-program.ts
@@ -198,6 +198,30 @@ describe("solana-program", () => {
       );
 
     expect(
+      streamAccount.creator.toBase58()
+    ).to.equal(creator.publicKey.toBase58());
+
+    expect(
+      streamAccount.recipient.toBase58()
+    ).to.equal(recipient.publicKey.toBase58());
+
+    expect(
+      streamAccount.mint.toBase58()
+    ).to.equal(mint.toBase58());
+
+    expect(
+      streamAccount.startTs.toString()
+    ).to.equal(startTs.toString());
+
+    expect(
+      streamAccount.endTs.toString()
+    ).to.equal(endTs.toString());
+
+    expect(
+      streamAccount.vault.toBase58()
+    ).to.equal(vault.toBase58());
+
+    expect(
       streamAccount.totalAmount.toString()
     ).to.equal(amount.toString());
 


### PR DESCRIPTION
what i'm doing this week:

create_stream instruction works: creator deposits tokens, specifies recipient, start date, end date
Tokens are locked in a PDA — creator cannot withdraw them back
Unit tests cover: create stream