### PR TITLE
feat: add config PDA to milestone unlock and edit methods

### DIFF
--- a/backend/src/api/mcpServer.ts
+++ b/backend/src/api/mcpServer.ts
@@ -679,10 +679,16 @@ server.tool(
                 PROGRAM_ID
             );
 
+            const [configPda] = PublicKey.findProgramAddressSync(
+                [Buffer.from("config")],
+                PROGRAM_ID
+            );
+
             const tx = await program.methods
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+                    config: configPda,
                     stream: streamPubkey,
                     milestone: milestonePda,
                     systemProgram: SystemProgram.programId,
@@ -786,10 +792,16 @@ server.tool(
                         ),
                     ];
 
+            const [configPda] = PublicKey.findProgramAddressSync(
+                [Buffer.from("config")],
+                PROGRAM_ID
+            );
+
             const tx = await program.methods
                 .editMilestone(amountBN)
                 .accounts({
                     creator: creator.publicKey,
+                    config: configPda,
                     stream: streamPubkey,
                     milestone: milestonePda,
                     mint: mint,

--- a/backend/src/idl/unified_flow.json
+++ b/backend/src/idl/unified_flow.json
@@ -595,6 +595,24 @@
           ]
         },
         {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "stream",
           "writable": true,
           "pda": {
@@ -819,6 +837,24 @@
           "relations": [
             "stream"
           ]
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "stream",

--- a/cli/src/idl/unified_flow.json
+++ b/cli/src/idl/unified_flow.json
@@ -595,6 +595,24 @@
           ]
         },
         {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "stream",
           "writable": true,
           "pda": {
@@ -819,6 +837,24 @@
           "relations": [
             "stream"
           ]
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "stream",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -737,11 +737,13 @@ ${C_BLUE}${C_BOLD}🌊 Vesting Stream Details:${C_RESET}
                     PROGRAM_ID
                 );
 
+                const [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], PROGRAM_ID);
                 logInfo(`Unlocking milestone #${nextIndex} (${milestonePda.toBase58()})...`);
                 const tx = await program.methods
                     .unlockMilestone()
                     .accountsStrict({
                         creator: signer.publicKey,
+                        config: configPda,
                         stream: streamPubkey,
                         milestone: milestonePda,
                         systemProgram: SystemProgram.programId,
@@ -792,11 +794,13 @@ ${C_BLUE}${C_BOLD}🌊 Vesting Stream Details:${C_RESET}
                     ),
                 ];
 
+                const [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], PROGRAM_ID);
                 logInfo(`Modifying milestone #${idx} allocation to ${amtStr} tokens...`);
                 const tx = await program.methods
                     .editMilestone(newAmountBN)
                     .accounts({
                         creator: signer.publicKey,
+                        config: configPda,
                         stream: streamPubkey,
                         milestone: milestonePda,
                         mint: mint,

--- a/coverage-tests/tests/program_test.rs
+++ b/coverage-tests/tests/program_test.rs
@@ -448,6 +448,7 @@ async fn store_milestone(&mut self, key: Pubkey, milestone: MilestoneAccount) {
         let data = unified_flow::instruction::UnlockMilestone {}.data();
         let metas = unified_flow::accounts::UnlockMilestone {
             creator: self.creator.pubkey(),
+            config: Self::config_pda(),
             stream,
             milestone,
             system_program: system_program::id(),
@@ -471,6 +472,7 @@ async fn store_milestone(&mut self, key: Pubkey, milestone: MilestoneAccount) {
         let data = unified_flow::instruction::EditMilestone { new_amount }.data();
         let metas = unified_flow::accounts::EditMilestone {
             creator: self.creator.pubkey(),
+            config: Self::config_pda(),
             stream,
             milestone,
             mint,

--- a/frontend/src/lib/idl/unified_flow.json
+++ b/frontend/src/lib/idl/unified_flow.json
@@ -595,6 +595,24 @@
           ]
         },
         {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "stream",
           "writable": true,
           "pda": {
@@ -819,6 +837,24 @@
           "relations": [
             "stream"
           ]
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "stream",

--- a/frontend/src/lib/solana/edit-stream.ts
+++ b/frontend/src/lib/solana/edit-stream.ts
@@ -641,10 +641,13 @@ export async function editMilestoneOnChain({
 
 
 
+  const [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], PROGRAM_ID);
+
   const anchorInstruction = await program.methods
     .editMilestone(newAmount)
     .accounts({
       creator,
+      config: configPda,
       stream: streamAddress,
       milestone: milestoneAddress,
       mint,
@@ -663,6 +666,7 @@ export async function editMilestoneOnChain({
     anchorInstructionData: anchorInstruction.data,
     accounts: [
       { address: creator.toBase58(), role: AccountRole.WRITABLE_SIGNER, signer: walletSigner as any },
+      { address: configPda.toBase58(), role: AccountRole.READONLY },
       { address: streamAddress.toBase58(), role: AccountRole.WRITABLE },
       { address: milestoneAddress.toBase58(), role: AccountRole.WRITABLE },
       { address: mint.toBase58(), role: AccountRole.READONLY },

--- a/frontend/src/lib/solana/unlock-milestone.ts
+++ b/frontend/src/lib/solana/unlock-milestone.ts
@@ -119,10 +119,13 @@ export async function unlockMilestoneOnChain({
 
   const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash(commitment);
 
+  const [configPda] = PublicKey.findProgramAddressSync([Buffer.from("config")], PROGRAM_ID);
+
   const anchorInstruction = await program.methods
     .unlockMilestone()
     .accountsStrict({
       creator,
+      config: configPda,
       stream: streamAddress,
       milestone: milestoneAddress,
       systemProgram: SystemProgram.programId,
@@ -133,6 +136,7 @@ export async function unlockMilestoneOnChain({
     programAddress: PROGRAM_ID.toBase58(),
     accounts: [
       { address: creator.toBase58(), role: AccountRole.WRITABLE_SIGNER, signer: kitSigner },
+      { address: configPda.toBase58(), role: AccountRole.READONLY },
       { address: streamAddress.toBase58(), role: AccountRole.WRITABLE },
       { address: milestoneAddress.toBase58(), role: AccountRole.WRITABLE },
       { address: SystemProgram.programId.toBase58(), role: AccountRole.READONLY },

--- a/programs/unified-flow/benches/compute_units.rs
+++ b/programs/unified-flow/benches/compute_units.rs
@@ -235,6 +235,7 @@ fn main() {
         program_id: unified_flow::ID,
         accounts: vec![
             AccountMeta::new(harness.creator, true),
+            AccountMeta::new_readonly(config, false),
             AccountMeta::new(ms_stream, false),
             AccountMeta::new(milestone0, false),
             AccountMeta::new_readonly(system_program::ID, false),
@@ -358,6 +359,7 @@ fn main() {
         program_id: unified_flow::ID,
         accounts: vec![
             AccountMeta::new(harness.creator, true),
+            AccountMeta::new_readonly(config, false),
             AccountMeta::new(ms_stream, false),
             AccountMeta::new(milestone1, false),
             AccountMeta::new_readonly(mint, false),

--- a/programs/unified-flow/src/lib.rs
+++ b/programs/unified-flow/src/lib.rs
@@ -327,6 +327,8 @@ pub fn withdraw_fees(
     ctx: Context<WithdrawFees>,
     amount: u64,
 ) -> Result<()> {
+    require!(!ctx.accounts.config.paused, ErrorCode::ProtocolPaused);
+
     require_keys_eq!(
         ctx.accounts.admin.key(),
         ctx.accounts.config.fee_authority,
@@ -558,6 +560,8 @@ pub fn cancel(ctx: Context<Cancel>) -> Result<()> {
     Ok(())
 }
 pub fn unlock_milestone(ctx: Context<UnlockMilestone>) -> Result<()> {
+    require!(!ctx.accounts.config.paused, ErrorCode::ProtocolPaused);
+
     let stream = &mut ctx.accounts.stream;
     let milestone = &mut ctx.accounts.milestone;
 
@@ -611,6 +615,8 @@ pub fn edit_milestone(
     ctx: Context<EditMilestone>,
     new_amount: u64,
 ) -> Result<()> {
+    require!(!ctx.accounts.config.paused, ErrorCode::ProtocolPaused);
+
     let now = Clock::get()?.unix_timestamp;
     let stream = &mut ctx.accounts.stream;
     let milestone = &mut ctx.accounts.milestone;
@@ -1144,6 +1150,12 @@ pub struct EditMilestone<'info> {
     pub creator: Signer<'info>,
 
     #[account(
+        seeds = [b"config"],
+        bump = config.bump,
+    )]
+    pub config: Account<'info, ConfigAccount>,
+
+    #[account(
         mut,
         has_one = creator @ ErrorCode::Unauthorized,
         has_one = mint @ ErrorCode::InvalidMint,
@@ -1239,6 +1251,12 @@ pub struct InitializeConfig<'info> {
 pub struct UnlockMilestone<'info> {
     #[account(mut)]
     pub creator: Signer<'info>,
+
+    #[account(
+        seeds = [b"config"],
+        bump = config.bump,
+    )]
+    pub config: Account<'info, ConfigAccount>,
 
     #[account(
         mut,

--- a/programs/unified-flow/tests/common.rs
+++ b/programs/unified-flow/tests/common.rs
@@ -511,6 +511,7 @@ impl Harness {
             program_id: unified_flow::ID,
             accounts: vec![
                 AccountMeta::new(self.creator, true),
+                AccountMeta::new_readonly(Self::config_pda(), false),
                 AccountMeta::new(stream, false),
                 AccountMeta::new(milestone, false),
                 AccountMeta::new_readonly(system_program::ID, false),
@@ -534,6 +535,7 @@ impl Harness {
             program_id: unified_flow::ID,
             accounts: vec![
                 AccountMeta::new(self.creator, true),
+                AccountMeta::new_readonly(Self::config_pda(), false),
                 AccountMeta::new(stream, false),
                 AccountMeta::new(milestone, false),
                 AccountMeta::new_readonly(mint, false),

--- a/programs/unified-flow/tests/mollusk.rs
+++ b/programs/unified-flow/tests/mollusk.rs
@@ -367,6 +367,20 @@ fn withdraw_matrix() {
         data: ix_data("withdraw", &()),
     });
     assert_failed(&paused);
+
+    // withdraw_fees must also respect the global pause (pause guard runs first)
+    let fees_paused = harness.process_err(&Instruction {
+        program_id: unified_flow::ID,
+        accounts: vec![
+            AccountMeta::new(harness.admin, true),
+            AccountMeta::new_readonly(Harness::config_pda(), false),
+            AccountMeta::new(fee_vault, false),
+            AccountMeta::new(harness.stranger, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: ix_data("withdraw_fees", &1u64),
+    });
+    assert_failed(&fees_paused);
 }
 
 #[test]

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -381,10 +381,13 @@ export class UnifiedFlowClient {
     const creator = new PublicKey(this.wallet.account.address.toString());
     const milestonePDA = getMilestonePDA(streamPDA, milestoneIndex, this.program.programId)[0];
 
+    const config = this.getConfigPDA();
+
     const anchorIx = await this.program.methods
       .unlockMilestone()
       .accounts({
         creator,
+        config,
         stream: streamPDA,
         milestone: milestonePDA,
         systemProgram: SystemProgram.programId,
@@ -397,6 +400,7 @@ export class UnifiedFlowClient {
 
     const kitIx = this._toKitInstruction(anchorIx, [
       { address: creator.toBase58(), role: AccountRole.WRITABLE_SIGNER, signer: this.kitSigner },
+      { address: config.toBase58(), role: AccountRole.READONLY },
       { address: streamPDA.toBase58(), role: AccountRole.WRITABLE },
       { address: milestonePDA.toBase58(), role: AccountRole.WRITABLE },
       { address: SystemProgram.programId.toBase58(), role: AccountRole.READONLY },
@@ -459,10 +463,13 @@ export class UnifiedFlowClient {
           ),
         ];
 
+    const config = this.getConfigPDA();
+
     const anchorIx = await this.program.methods
       .editMilestone(newAmount)
       .accounts({
         creator,
+        config,
         stream: streamPDA,
         milestone: milestonePDA,
         mint,
@@ -478,6 +485,7 @@ export class UnifiedFlowClient {
 
     const kitIx = this._toKitInstruction(anchorIx, [
       { address: creator.toBase58(), role: AccountRole.WRITABLE_SIGNER, signer: this.kitSigner },
+      { address: config.toBase58(), role: AccountRole.READONLY },
       { address: streamPDA.toBase58(), role: AccountRole.WRITABLE },
       { address: milestonePDA.toBase58(), role: AccountRole.WRITABLE },
       { address: mint.toBase58(), role: AccountRole.READONLY },

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -601,6 +601,24 @@ export type UnifiedFlow = {
           ]
         },
         {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "stream",
           "writable": true,
           "pda": {
@@ -761,6 +779,51 @@ export type UnifiedFlow = {
       "args": []
     },
     {
+      "name": "setPause",
+      "discriminator": [
+        63,
+        32,
+        154,
+        2,
+        56,
+        103,
+        79,
+        45
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "paused",
+          "type": "bool"
+        }
+      ]
+    },
+    {
       "name": "unlockMilestone",
       "discriminator": [
         131,
@@ -780,6 +843,24 @@ export type UnifiedFlow = {
           "relations": [
             "stream"
           ]
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "stream",
@@ -1190,6 +1271,19 @@ export type UnifiedFlow = {
         152,
         104,
         241
+      ]
+    },
+    {
+      "name": "protocolPaused",
+      "discriminator": [
+        35,
+        111,
+        245,
+        138,
+        237,
+        199,
+        79,
+        223
       ]
     },
     {
@@ -1671,6 +1765,26 @@ export type UnifiedFlow = {
           {
             "name": "effectiveAt",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "protocolPaused",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "paused",
+            "type": "bool"
           }
         ]
       }

--- a/sdk/src/unified_flow.json
+++ b/sdk/src/unified_flow.json
@@ -595,6 +595,24 @@
           ]
         },
         {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "stream",
           "writable": true,
           "pda": {
@@ -819,6 +837,24 @@
           "relations": [
             "stream"
           ]
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "stream",

--- a/tests/cancel.ts
+++ b/tests/cancel.ts
@@ -545,6 +545,8 @@ describe("cancel", () => {
       .unlockMilestone()
       .accountsStrict({
         creator: creator.publicKey,
+
+        config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
         stream: streamPda,
         milestone: milestonePdas[0],
         systemProgram: SystemProgram.programId,
@@ -578,6 +580,8 @@ describe("cancel", () => {
         .unlockMilestone()
         .accountsStrict({
           creator: creator.publicKey,
+
+          config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
           stream: streamPda,
           milestone: milestonePdas[i],
           systemProgram: SystemProgram.programId,
@@ -728,6 +732,8 @@ describe("cancel", () => {
         .unlockMilestone()
         .accountsStrict({
           creator: creator.publicKey,
+
+          config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
           stream: streamPda,
           milestone: milestonePda,
           systemProgram: SystemProgram.programId,

--- a/tests/edit-milestone.ts
+++ b/tests/edit-milestone.ts
@@ -395,6 +395,8 @@ describe("edit-milestone", () => {
             .editMilestone(newAmount)
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -427,6 +429,8 @@ describe("edit-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[0],
                 systemProgram: SystemProgram.programId,
@@ -439,6 +443,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -471,6 +477,8 @@ describe("edit-milestone", () => {
             .editMilestone(newAmount)
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -519,6 +527,8 @@ describe("edit-milestone", () => {
             .editMilestone(sameAmount)
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -560,6 +570,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(0))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -593,6 +605,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: fakeMilestonePda,
                     mint,
@@ -642,6 +656,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -672,6 +688,7 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: recipient.publicKey,  // bukan creator asli
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -709,6 +726,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(1))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[1],
                 mint,
@@ -750,6 +769,8 @@ describe("edit-milestone", () => {
             .editMilestone(newAmount)
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -794,6 +815,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(500_000))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -812,6 +835,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(100_000))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -830,6 +855,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(300_000))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePda,
                 mint,
@@ -862,6 +889,8 @@ describe("edit-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[0],
                 systemProgram: SystemProgram.programId,
@@ -873,6 +902,8 @@ describe("edit-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[1],
                 systemProgram: SystemProgram.programId,
@@ -889,6 +920,8 @@ describe("edit-milestone", () => {
             .editMilestone(newAmount)
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[3],
                 mint,
@@ -920,6 +953,8 @@ describe("edit-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[0],
                 systemProgram: SystemProgram.programId,
@@ -936,6 +971,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -970,6 +1007,8 @@ describe("edit-milestone", () => {
         await program.methods.unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[0],
                 systemProgram: SystemProgram.programId,
@@ -1075,6 +1114,8 @@ describe("edit-milestone", () => {
         await program.methods.unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[0],
                 systemProgram: SystemProgram.programId,
@@ -1117,6 +1158,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(1))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[1],
                 mint,
@@ -1160,6 +1203,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: attacker.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[1],
                     mint,
@@ -1192,6 +1237,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamA,
                     milestone: milestonesB[0], // milestone dari stream lain
                     mint,
@@ -1223,6 +1270,8 @@ describe("edit-milestone", () => {
                 .editMilestone(u64Max)
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -1254,6 +1303,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(1))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[0],
                 mint,
@@ -1289,6 +1340,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamA,
                     milestone: milestonesA[1],
                     mint,
@@ -1323,6 +1376,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(999_999_999))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -1428,6 +1483,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(350_000))
                 .accountsStrict({
                     creator: freshCreator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -1469,6 +1526,7 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: recipient.publicKey,   // recipient impersonate creator
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -1501,6 +1559,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: streamPda,  // stream dipass sebagai milestone
                     mint,
@@ -1528,6 +1588,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(300_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[1],
                     mint,
@@ -1557,6 +1619,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(100_000))
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPda,
                     milestone: milestonePdas[0],
                     mint,
@@ -1589,6 +1653,8 @@ describe("edit-milestone", () => {
             .editMilestone(new BN(350_000))
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPda,
                 milestone: milestonePdas[2],
                 mint,
@@ -1636,6 +1702,8 @@ describe("edit-milestone", () => {
                 .editMilestone(new BN(1))   // decrease → harusnya drain vaultB
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamB,          // target stream B
                     milestone: milestonesA[0], // milestone dari stream A
                     mint,

--- a/tests/unlock-milestone.ts
+++ b/tests/unlock-milestone.ts
@@ -333,6 +333,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[i].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -356,6 +358,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: stranger.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[0].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -377,6 +381,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[1].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -397,6 +403,8 @@ describe("unlock-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPDA,
                 milestone: remainingAccounts[0].pubkey,
                 systemProgram: anchor.web3.SystemProgram.programId,
@@ -411,6 +419,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[0].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -453,6 +463,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[0].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -509,6 +521,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: linearStreamPDA,
                     milestone: fakeMilestonePda,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -541,6 +555,8 @@ describe("unlock-milestone", () => {
             await program.methods.unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[i].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -580,6 +596,8 @@ describe("unlock-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPDA,
                 milestone: remainingAccounts[0].pubkey,
                 systemProgram: anchor.web3.SystemProgram.programId,
@@ -602,6 +620,8 @@ describe("unlock-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPDA,
                 milestone: remainingAccounts[0].pubkey,
                 systemProgram: anchor.web3.SystemProgram.programId,
@@ -662,6 +682,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creatorB.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamA,
                     milestone: milestonesA[0].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -688,6 +710,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamA,
                     milestone: milestonesB[0].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -725,6 +749,8 @@ describe("unlock-milestone", () => {
             await program.methods.unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[i].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -758,6 +784,8 @@ describe("unlock-milestone", () => {
         await program.methods.unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPDA,
                 milestone: remainingAccounts[0].pubkey,
                 systemProgram: anchor.web3.SystemProgram.programId,
@@ -794,6 +822,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: recipient.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[0].pubkey,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -815,6 +845,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: streamPDA,
                     systemProgram: anchor.web3.SystemProgram.programId,
@@ -836,6 +868,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: remainingAccounts[0].pubkey,
                     systemProgram: TOKEN_PROGRAM_ID,
@@ -865,6 +899,8 @@ describe("unlock-milestone", () => {
             .unlockMilestone()
             .accountsStrict({
                 creator: creator.publicKey,
+
+                config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                 stream: streamPDA,
                 milestone: remainingAccounts[0].pubkey,
                 systemProgram: anchor.web3.SystemProgram.programId,
@@ -890,6 +926,8 @@ describe("unlock-milestone", () => {
                 .unlockMilestone()
                 .accountsStrict({
                     creator: creator.publicKey,
+
+                    config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
                     stream: streamPDA,
                     milestone: streamPDA,
                     systemProgram: anchor.web3.SystemProgram.programId,

--- a/tests/withdraw.ts
+++ b/tests/withdraw.ts
@@ -788,6 +788,8 @@ describe("withdraw", () => {
         .unlockMilestone()
         .accountsStrict({
           creator: creator.publicKey,
+
+          config: PublicKey.findProgramAddressSync([Buffer.from("config")], program.programId)[0],
           stream: streamPda,
           milestone: milestonePda,
           systemProgram: SystemProgram.programId,

--- a/trident-tests/fuzz_0/types.rs
+++ b/trident-tests/fuzz_0/types.rs
@@ -693,6 +693,8 @@ pub mod unified_flow {
     pub struct EditMilestoneInstructionAccountMetas {
         pub creator: AccountMeta,
 
+        pub config: AccountMeta,
+
         pub stream: AccountMeta,
 
         pub milestone: AccountMeta,
@@ -711,6 +713,8 @@ pub mod unified_flow {
     pub struct EditMilestoneInstructionAccounts {
         pub creator: Pubkey,
 
+        pub config: Pubkey,
+
         pub stream: Pubkey,
 
         pub milestone: Pubkey,
@@ -728,6 +732,8 @@ pub mod unified_flow {
         pub fn new(
             creator: Pubkey,
 
+            config: Pubkey,
+
             stream: Pubkey,
 
             milestone: Pubkey,
@@ -742,6 +748,8 @@ pub mod unified_flow {
         ) -> Self {
             Self {
                 creator,
+
+                config,
 
                 stream,
 
@@ -787,6 +795,8 @@ pub mod unified_flow {
         pub fn accounts(mut self, accounts: EditMilestoneInstructionAccounts) -> Self {
             self.accounts.creator = AccountMeta::new(accounts.creator, true);
 
+            self.accounts.config = AccountMeta::new_readonly(accounts.config, false);
+
             self.accounts.stream = AccountMeta::new(accounts.stream, false);
 
             self.accounts.milestone = AccountMeta::new(accounts.milestone, false);
@@ -812,6 +822,8 @@ pub mod unified_flow {
             let mut metas = Vec::new();
 
             metas.push(self.accounts.creator.clone());
+
+            metas.push(self.accounts.config.clone());
 
             metas.push(self.accounts.stream.clone());
 
@@ -955,6 +967,8 @@ pub mod unified_flow {
     pub struct UnlockMilestoneInstructionAccountMetas {
         pub creator: AccountMeta,
 
+        pub config: AccountMeta,
+
         pub stream: AccountMeta,
 
         pub milestone: AccountMeta,
@@ -967,15 +981,19 @@ pub mod unified_flow {
     pub struct UnlockMilestoneInstructionAccounts {
         pub creator: Pubkey,
 
+        pub config: Pubkey,
+
         pub stream: Pubkey,
 
         pub milestone: Pubkey,
     }
 
     impl UnlockMilestoneInstructionAccounts {
-        pub fn new(creator: Pubkey, stream: Pubkey, milestone: Pubkey) -> Self {
+        pub fn new(creator: Pubkey, config: Pubkey, stream: Pubkey, milestone: Pubkey) -> Self {
             Self {
                 creator,
+
+                config,
 
                 stream,
 
@@ -1011,6 +1029,8 @@ pub mod unified_flow {
         pub fn accounts(mut self, accounts: UnlockMilestoneInstructionAccounts) -> Self {
             self.accounts.creator = AccountMeta::new(accounts.creator, true);
 
+            self.accounts.config = AccountMeta::new_readonly(accounts.config, false);
+
             self.accounts.stream = AccountMeta::new(accounts.stream, false);
 
             self.accounts.milestone = AccountMeta::new(accounts.milestone, false);
@@ -1030,6 +1050,8 @@ pub mod unified_flow {
             let mut metas = Vec::new();
 
             metas.push(self.accounts.creator.clone());
+
+            metas.push(self.accounts.config.clone());
 
             metas.push(self.accounts.stream.clone());
 


### PR DESCRIPTION
- Introduced a new config PDA to the unlockMilestone and editMilestone methods in the mcpServer and corresponding client files.
- Updated the IDL files to include the new config account.
- Modified the frontend and CLI to utilize the config PDA in relevant transactions.
- Enhanced tests to ensure the config PDA is correctly passed in unlock and edit milestone scenarios.
- Implemented checks in the Rust program to enforce protocol pause functionality using the config account.